### PR TITLE
Use git-version plugin

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,9 +1,18 @@
+import com.palantir.gradle.gitversion.VersionDetails
+
 plugins {
     id("org.springframework.boot") version "2.2.4.RELEASE" apply false
     id("io.spring.dependency-management") version "1.0.9.RELEASE" apply false
     kotlin("jvm") version "1.3.61" apply false
     kotlin("plugin.spring") version "1.3.61" apply false
+    id("com.palantir.git-version") version "0.12.2" apply false
 }
 
-group = "github.chickenbane"
-version = "0.0.1-SNAPSHOT"
+allprojects {
+    apply(plugin = "com.palantir.git-version")
+
+    fun getVersionDetails(): VersionDetails = (extra["versionDetails"] as groovy.lang.Closure<*>)() as VersionDetails
+
+    group = "github.chickenbane"
+    version= getVersionDetails().version
+}

--- a/rest/build.gradle.kts
+++ b/rest/build.gradle.kts
@@ -44,3 +44,7 @@ tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
         jvmTarget = "1.8"
     }
 }
+
+tasks.withType<ProcessResources> {
+    expand(project.properties)
+}

--- a/rest/src/main/resources/application.properties
+++ b/rest/src/main/resources/application.properties
@@ -1,0 +1,3 @@
+info.app.name=${name}
+info.app.version=${version}
+info.app.group=${group}


### PR DESCRIPTION
The project version is now determined by git.  That is, Gradle's project version (`./gradlew printVersion`), is the same as the output of `git describe`.

Use GitHub releases or `git tag` to create a new version at a specific gitsha.
Otherwise, the version is calculated by the number of commits away from the previous version, plus the current gitsha:
```
$ git describe
v1.0.0-1-gfd83bed
$ ./gradlew :printVersion
> Task :printVersion
v1.0.0-1-gfd83bed

```